### PR TITLE
1.7-release candidate 2

### DIFF
--- a/NameplatesThreat.lua
+++ b/NameplatesThreat.lua
@@ -80,6 +80,8 @@ local function threatSituation(monster)
             tankValue = threatValue
         elseif status and threatValue > offTankValue then
             offTankValue = threatValue
+        elseif UnitIsUnit(unit, monster .. "target") then
+            threatStatus = 5 -- ensure threat status if monster is targeting an offtank
         end
     end
     -- store if the player is tanking, or store their threat value if higher than others
@@ -98,10 +100,9 @@ local function threatSituation(monster)
             tankValue = threatValue
         elseif status and threatValue > nonTankValue then
             nonTankValue = threatValue
+        elseif UnitIsUnit(unit, monster .. "target") then
+            threatStatus = 0 -- ensure threat status if monster is targeting a nontank
         end
-    end
-    if threatStatus < 0 and UnitIsFriend("player", monster .. "target") then
-        threatStatus = 0 -- ensure threat status if monster is targeting a friend
     end
     -- deliver the stored information describing threat situation for this monster
     return threatStatus, tankValue, offTankValue, playerValue, nonTankValue

--- a/NameplatesThreat.lua
+++ b/NameplatesThreat.lua
@@ -151,28 +151,28 @@ local function updateThreatColor(frame)
 
         -- only recalculate color when situation was actually changed with gradient toward sibling color
         if not frame.threat or frame.threat.lastThreat ~= threat or frame.threat.lastPercent ~= percent then
-            local r, g, b = 0.6, 0.2, 0.8   -- magenta outside combat (colors below 4 inverted for nontanks)
+            local r, g, b = 0.69,0.69,0.69  -- gray outside combat (colors below 4 inverted for nontanks)
 
             if threat >= 4 then             -- group tanks are tanking
-                r = r-(1-percent)*0.4       -- blue/magenta no problem
-                g = g+(1-percent)*0.3
-                b = b+(1-percent)*0.1
+                r, g, b = 0.00,0.85,0.00    -- green/gray   no problem
+                r = r+(1-percent)*0.69
+                g = g-(1-percent)*0.16
+                b = b+(1-percent)*0.69
             elseif threat >= 3 then         -- player tanking by threat
-                r, g, b = 0.0, 0.5, 0.0     -- green/yellow disengage
-                r = r + percent * 1.0
-                g = g + percent * 0.5
-                b = b + percent * 0.4
+                r = r + percent * 0.31      -- gray/yellow  disengage
+                g = g + percent * 0.31
+                b = b - percent * 0.22
             elseif threat >= 2 then         -- player tanking by force
-                r, g, b = 1.0, 1.0, 0.4     -- yellow/green attack soon
-                r = r - percent * 1.0
-                g = g - percent * 0.5
-                b = b - percent * 0.4
+                r, g, b = 1.00,1.00,0.47    -- yellow/gray  attack soon
+                r = r - percent * 0.31
+                g = g - percent * 0.31
+                b = b + percent * 0.22
             elseif threat >= 1 then         -- others tanking by force
-                r, g, b = 1.0, 0.5, 0.0     -- orange/red   taunt now
-                g = g - percent * 0.5
+                r, g, b = 1.00,0.60,0.00    -- orange/red   taunt now
+                g = g - percent * 0.60
             elseif threat >= 0 then         -- others tanking by threat
-                r, g, b = 1.0, 0.0, 0.0     -- red/orange   attack now
-                g = g + percent * 0.5
+                r, g, b = 1.00,0.00,0.00    -- red/orange   attack now
+                g = g + percent * 0.60
             end
 
             if not frame.threat then

--- a/NameplatesThreat.lua
+++ b/NameplatesThreat.lua
@@ -81,7 +81,7 @@ local function threatSituation(monster)
         elseif status and threatValue > offTankValue then
             offTankValue = threatValue
         elseif UnitIsUnit(unit, monster .. "target") then
-            threatStatus = 5 -- ensure threat status if monster is targeting an offtank
+            threatStatus = 5 -- ensure threat status if monster is targeting a tank
         end
     end
     -- store if the player is tanking, or store their threat value if higher than others
@@ -100,9 +100,14 @@ local function threatSituation(monster)
             tankValue = threatValue
         elseif status and threatValue > nonTankValue then
             nonTankValue = threatValue
-        elseif UnitIsUnit(unit, monster .. "target") then
-            threatStatus = 0 -- ensure threat status if monster is targeting a nontank
         end
+    end
+    if threatStatus < 0 and UnitIsFriend("player", monster .. "target") then
+        threatStatus = 0 -- ensure threat status if monster is targeting a friend
+        tankValue    = 0
+        offTankValue = 0
+        playerValue  = 0
+        nonTankValue = 0
     end
     -- deliver the stored information describing threat situation for this monster
     return threatStatus, tankValue, offTankValue, playerValue, nonTankValue

--- a/NameplatesThreat.lua
+++ b/NameplatesThreat.lua
@@ -46,7 +46,7 @@ local function collectOffTanks()
         unit = unitPrefix .. i
         if not UnitIsUnit(unit, "player") then
             unitRole = UnitGroupRolesAssigned(unit)
-            if isInRaid and unitRole == "NONE" then
+            if isInRaid and unitRole ~= "TANK" then
                 _, _, _, _, _, _, _, _, _, unitRole = GetRaidRosterInfo(i)
                 if unitRole == "MAINTANK" then
                     unitRole = "TANK"
@@ -143,7 +143,7 @@ local function updateThreatColor(frame)
 
         -- only recalculate color when situation was actually changed with gradient toward sibling color
         if not frame.threat or frame.threat.lastThreat ~= threat or frame.threat.lastPercent ~= percent then
-            local r, g, b = 0.69,0.69,0.69  -- gray outside combat (colors below 4 inverted for nontanks)
+            local r, g, b = 0.29,0.29,0.29  -- dark outside combat (colors below 4 inverted for nontanks)
 
             if threat >= 4 then             -- group tanks are tanking
                 r, g, b = 0.00, 0.85, 0.00  -- green/gray   no problem
@@ -223,9 +223,8 @@ myFrame:SetScript("OnEvent", function(self, event, arg1)
         if nameplate then
             resetFrame(nameplate.UnitFrame)
         end
-    elseif event == "PLAYER_ROLES_ASSIGNED" or event == "RAID_ROSTER_UPDATE" then
-        offTanks, nonTanks = collectOffTanks()
-    elseif event == "PLAYER_SPECIALIZATION_CHANGED" or event == "PLAYER_ENTERING_WORLD" then
+    elseif event == "PLAYER_ROLES_ASSIGNED" or event == "RAID_ROSTER_UPDATE" or
+           event == "PLAYER_SPECIALIZATION_CHANGED" or event == "PLAYER_ENTERING_WORLD" then
         offTanks, nonTanks = collectOffTanks()
         playerRole = GetSpecializationRole(GetSpecialization())
     end

--- a/NameplatesThreat.lua
+++ b/NameplatesThreat.lua
@@ -91,13 +91,11 @@ end
 
 local function updateThreatColor(frame)
     local unit = frame.unit
-    -- http://wowwiki.wikia.com/wiki/API_UnitReaction
-    local reaction = UnitReaction("player", unit)
-    if reaction
-            and reaction < 5
-            and (reaction < 4 or CompactUnitFrame_IsOnThreatListWithPlayer(frame.displayedUnit))
-            and not UnitIsPlayer(unit)
-            and not CompactUnitFrame_IsTapDenied(frame) then
+    local reaction = UnitAffectingCombat(unit)
+
+    if UnitCanAttack("player", unit)
+        and (reaction or UnitAffectingCombat("player") or UnitReaction(unit, "player") < 4)
+        and not UnitIsPlayer(unit) and not CompactUnitFrame_IsTapDenied(frame) then
         --[[
             threat:
            -1 = not on threat table (not in combat).
@@ -110,7 +108,7 @@ local function updateThreatColor(frame)
         local _, threat, _, percent = UnitDetailedThreatSituation("player", unit)
         if not threat then
             percent = 0
-            if UnitAffectingCombat(unit) then
+            if reaction then
                 threat = 0
             else
                 threat = -1
@@ -229,7 +227,7 @@ myFrame:SetScript("OnEvent", function(self, event, arg1)
         playerRole = GetSpecializationRole(GetSpecialization())
     end
 end);
-if lastUpdate > 0 then -- one nameplate updated on every frame rendered over 30 fps
+if lastUpdate > 0 then -- one nameplate updated on every frame rendered over 45 fps
     myFrame:SetScript("OnUpdate", function(self, elapsed)
         local nameplate = C_NamePlate.GetNamePlates()
         if lastUpdate < #nameplate then
@@ -238,7 +236,7 @@ if lastUpdate > 0 then -- one nameplate updated on every frame rendered over 30 
             lastUpdate = 1
         end
         nameplate = nameplate[lastUpdate]
-        if nameplate and GetFramerate() > 30 then
+        if nameplate and GetFramerate() > 45 then
             updateThreatColor(nameplate.UnitFrame)
         end
     end);

--- a/NameplatesThreat.lua
+++ b/NameplatesThreat.lua
@@ -91,7 +91,7 @@ end
 
 local function updateThreatColor(frame)
     local unit = frame.unit
-    local reaction = UnitAffectingCombat(unit)
+    local reaction = UnitIsFriend("player", unit .. "target")
 
     if UnitCanAttack("player", unit)
         and (reaction or UnitAffectingCombat("player") or UnitReaction(unit, "player") < 4)

--- a/NameplatesThreat.toc
+++ b/NameplatesThreat.toc
@@ -1,5 +1,5 @@
 ## Interface: 70300
 ## Title: Blizzard Nameplates - Threat
 ## Notes: Colors the nameplate healthbar according to threat.
-## Version: 1.6
+## Version: 1.7
 NameplatesThreat.lua


### PR DESCRIPTION
Percentage gradients should be a lot more precise now.
Recolored to match GetThreatStatusColor (link below).
http://wowwiki.wikia.com/wiki/API_GetThreatStatusColor
Flipped when player is tank, green if a tank is tanking.
Only update every 0.2 seconds instead of every frame.