### PR TITLE
2.2-release candidate 1

### DIFF
--- a/NamePlatesThreat.lua
+++ b/NamePlatesThreat.lua
@@ -1,17 +1,17 @@
 local function initVariables(oldAcct) -- only the variables below are used by the addon
 	local newAcct, key, value = {}
 	newAcct["addonsEnabled"] = true  -- color by threat those nameplates you can attack
-	newAcct["colBorderOnly"] = true  -- ignore healthbar and color nameplate border instead
-	newAcct["showPetThreat"] = false -- include pets as offtanks when coloring nameplates
+	newAcct["colBorderOnly"] = false -- ignore healthbar and color nameplate border instead
+	newAcct["showPetThreat"] = true  -- include pets as offtanks when coloring nameplates
 	newAcct["enableOutside"] = true  -- also color nameplates outside PvE instances
 	newAcct["enableNoFight"] = true  -- also color nameplates not fighting your group
 	newAcct["hostilesColor"] = {r=163, g= 48, b=201} -- violet hostile not in group fight
 	newAcct["neutralsColor"] = {r=  0, g=112, b=222} -- blue   neutral not in group fight
 	newAcct["enablePlayers"] = false -- also color nameplates for player characters
 	newAcct["pvPlayerColor"] = {r=245, g=140, b=186} -- pink   player not in group fight
-	newAcct["gradientColor"] = false -- update nameplate color gradients (some CPU usage)
+	newAcct["gradientColor"] = true  -- update nameplate color gradients (some CPU usage)
 	newAcct["gradientPrSec"] = 5	 -- update color gradients this many times per second
-	newAcct["youTankCombat"] = true -- unique colors in combat instead of colors above
+	newAcct["youTankCombat"] = true  -- unique colors in combat instead of colors above
 	newAcct["youTank7color"] = {r=255, g=  0, b=  0} -- red    healers tanking by threat
 	newAcct["youTank0color"] = {r=255, g=153, b=  0} -- orange others tanking by threat
 	newAcct["youTank2color"] = {r=255, g=255, b=120} -- yellow you are tanking by force	* v reuse 4	gray

--- a/NamePlatesThreat.toc
+++ b/NamePlatesThreat.toc
@@ -1,7 +1,7 @@
-## Interface: 80100
+## Interface: 80200
 ## Title: NamePlatesThreat
 ## Notes: Colors the nameplate healthbar according to threat.
-## Version: 2.1
+## Version: 2.2
 ## Author: int3ro, exochron & mikfhan
 ## SavedVariables: NPTacct
 NamePlatesThreat.lua


### PR DESCRIPTION
For patch 8.2 setting gradient coloring 5 times per second as default and full healthbar coloring instead of border only, and coloring group pets as offtanks.
All settings can still be tweaked from Escape menu > Interface > AddOns > NamePlatesThreat.