### PR TITLE
3.5-release

### DIFF
--- a/NamePlatesThreat.lua
+++ b/NamePlatesThreat.lua
@@ -9,7 +9,7 @@ local function initVariables(oldAcct) -- only the variables below are used by th
 	newAcct["neutralsColor"] = {r=  0, g=112, b=222} -- blue   neutral not in group fight
 	newAcct["enablePlayers"] = true  -- also color nameplates for player characters
 	newAcct["pvPlayerColor"] = {r=245, g=140, b=186} -- pink   player not in group fight
-	newAcct["gradientColor"] = true -- update nameplate color gradients (some CPU usage)
+	newAcct["gradientColor"] = false -- update nameplate color gradients (some CPU usage)
 	newAcct["gradientPrSec"] = 5	 -- update color gradients this many times per second
 	newAcct["youTankCombat"] = true  -- unique colors in combat instead of colors above
 	newAcct["youTank7color"] = {r=255, g=  0, b=  0} -- red    healers tanking by threat

--- a/NamePlatesThreat.lua
+++ b/NamePlatesThreat.lua
@@ -153,33 +153,35 @@ local function getGroupRoles()
 			break
 		elseif UnitExists(unit) then
 			unitRole = UnitGroupRolesAssigned(unit)
-			if unitRole ~= "HEALER" then
-				if unitPrefix == "raid" then
-					_, raidRank, _, _, _, _, _, _, _, unitRole = GetRaidRosterInfo(i)
-				elseif UnitIsGroupLeader(unit) then
+			if unitRole ~= "TANK" and unitRole ~= "HEALER" then
+				if UnitIsGroupLeader(unit) then
 					raidRank = 3
+				elseif unitPrefix == "raid" then
+					_, raidRank, _, _, _, _, _, _, _, unitRole = GetRaidRosterInfo(i)
+				else
+					raidRank = 0
 				end
 				if unitRole == "MAINTANK" or unitRole == "MAINASSIST" or raidRank > 0 then
 					unitRole = "TANK"
 				end
 			end
-		end
-		if UnitIsUnit(unit, "player") then
-			collectedPlayer = unitRole
-		elseif unitRole ~= "NONE" then
-			if unitRole == "TANK" then
-				table.insert(collectedTanks, unit)
-			elseif unitRole == "HEALER" then
-				table.insert(collectedHeals, unit)
+			if UnitIsUnit(unit, "player") then
+				collectedPlayer = unitRole
 			else
-				table.insert(collectedOther, unit)
-			end
-			unit = unitPrefix .. "pet" .. i
-			if UnitExists(unit) then
-				if NPTacct.showPetThreat or unitRole == "TANK" then
+				if unitRole == "TANK" then
 					table.insert(collectedTanks, unit)
+				elseif unitRole == "HEALER" then
+					table.insert(collectedHeals, unit)
 				else
 					table.insert(collectedOther, unit)
+				end
+				unit = unitPrefix .. "pet" .. i
+				if UnitExists(unit) then
+					if NPTacct.showPetThreat or unitRole == "TANK" then
+						table.insert(collectedTanks, unit)
+					else
+						table.insert(collectedOther, unit)
+					end
 				end
 			end
 		end

--- a/NamePlatesThreat.lua
+++ b/NamePlatesThreat.lua
@@ -713,11 +713,12 @@ NPT:SetScript("OnEvent", function(self, event, arg1)
 							NPT.playerRole = "HEALER"
 						end
 					else
-						for _, unit in ipairs(NPT.nonTanks) do
+						local key, unit
+						for key, unit in pairs(NPT.nonTanks) do
 							if sourceGUID == UnitGUID(unit) then
 								--print(unit .. " is now HEALER")
 								table.insert(NPT.offHeals, unit)
-								table.remove(NPT.nonTanks, unit)
+								table.remove(NPT.nonTanks, key)
 								break
 							end
 						end
@@ -732,11 +733,12 @@ NPT:SetScript("OnEvent", function(self, event, arg1)
 							NPT.playerRole = "DAMAGER"
 						end
 					else
-						for _, unit in ipairs(NPT.offHeals) do
+						local key, unit
+						for key, unit in pairs(NPT.offHeals) do
 							if sourceGUID == UnitGUID(unit) then
 								--print(unit .. " is now DAMAGER")
 								table.insert(NPT.nonTanks, unit)
-								table.remove(NPT.offHeals, unit)
+								table.remove(NPT.offHeals, key)
 								break
 							end
 						end

--- a/NamePlatesThreat.lua
+++ b/NamePlatesThreat.lua
@@ -624,7 +624,38 @@ local function callback()
 		NPT.thisUpdate = 0
 	end
 end
+-- mikfhan TODO: pseudocode for Classic Era assigning temporary healers via combatlog
+--[[
+initial array of healer potentials with their guid as key and timestamp as value
+(note this overrides healer group role to damage if not seen healing for x seconds)
+cleared before group/roster is updated, then register new event when someone heals:
 
+on event COMBAT_LOG_HEAL
+if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+ & GetNumGroupMembers() > 0
+ & sourceFlags == 0x0517 (type/control:player,reaction:friendly,affiliation:groupmember)
+	potentials[guid] = event timestamp
+	recent = event timestamp - x seconds
+	playerid = guid(player)
+	iterate i potentials
+		guid = guid(i)
+		if timestamp(i) >= recent
+			if guid == playerid
+				if playerrole == "DAMAGER" then playerrole = "HEALER"
+			else iterate j others
+				if guid(j) == guid
+					healers.insert(j)
+					others.remove(j)
+					break
+		else
+			if guid == playerid
+				if playerrole == "HEALER" then playerrole = "DAMAGER"
+			else iterate j healers
+				if guid(j) == guid
+					others.insert(j)
+					healers.remove(j)
+					break
+--]]
 --NPT:RegisterEvent("UNIT_COMBAT")
 --NPT:RegisterEvent("UNIT_ATTACK")
 --NPT:RegisterEvent("UNIT_DEFENSE")

--- a/NamePlatesThreat.lua
+++ b/NamePlatesThreat.lua
@@ -66,7 +66,11 @@ NPTframe.lastSwatch = nil
 local function resetFrame(plate)
 	if plate.UnitFrame.unit and UnitCanAttack("player", plate.UnitFrame.unit) then
 		if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
-			plate.UnitFrame.healthBar.border:SetVertexColor(0, 0, 0, 1)
+			if UnitIsUnit(plate.UnitFrame.unit, "target") then
+				plate.UnitFrame.healthBar.border:SetVertexColor(1, 1, 1, 1)
+			else
+				plate.UnitFrame.healthBar.border:SetVertexColor(0, 0, 0, 1)
+			end
 		end
 		plate.UnitFrame.healthBar:SetStatusBarColor(plate.UnitFrame.healthBar.r, plate.UnitFrame.healthBar.g, plate.UnitFrame.healthBar.b, plate.UnitFrame.healthBar.a)
 	end

--- a/NamePlatesThreat.lua
+++ b/NamePlatesThreat.lua
@@ -719,6 +719,7 @@ NPT:SetScript("OnEvent", function(self, event, arg1)
 				end
 			elseif subevent == "SPELL_DAMAGE" or subevent == "SPELL_PERIODIC_DAMAGE" then
 				if NPT.nonHeals[sourceGUID] and NPT.nonHeals[sourceGUID] < timestamp - 60 then
+					NPT.nonHeals[sourceGUID] = nil
 					if sourceGUID == UnitGUID("player") then
 						if NPT.playerRole == "HEALER" then
 							--print("player is now DAMAGER")

--- a/NamePlatesThreat.lua
+++ b/NamePlatesThreat.lua
@@ -693,7 +693,7 @@ NPT:SetScript("OnEvent", function(self, event, arg1)
 			resetFrame(plate)
 		end
 	elseif event == "COMBAT_LOG_EVENT_UNFILTERED" and GetNumGroupMembers() > 0 then
-		local timestamp, subevent, _, sourceGUID, _, sourceFlags = CombatLogGetCurrentEventInfo()
+		local timestamp, subevent, _, sourceGUID, _, sourceFlags, _, destGUID = CombatLogGetCurrentEventInfo()
 		local COMBATLOG_FILTER_GROUPHEAL = bit.bor(
 			COMBATLOG_OBJECT_AFFILIATION_MINE
 		,	COMBATLOG_OBJECT_AFFILIATION_PARTY
@@ -705,19 +705,21 @@ NPT:SetScript("OnEvent", function(self, event, arg1)
 		if CombatLog_Object_IsA(sourceFlags, COMBATLOG_FILTER_GROUPHEAL) then
 			--print(timestamp .. " " .. sourceGUID .. " " .. format("0x%X", sourceFlags))
 			if subevent == "SPELL_HEAL" or subevent == "SPELL_PERIODIC_HEAL" then
-				NPT.nonHeals[sourceGUID] = timestamp
-				if sourceGUID == UnitGUID("player") then
-					if NPT.playerRole == "DAMAGER" then
-						--print("player is now HEALER")
-						NPT.playerRole = "HEALER"
-					end
-				else
-					for _, unit in ipairs(NPT.nonTanks) do
-						if sourceGUID == UnitGUID(unit) then
-							--print(unit .. " is now HEALER")
-							table.insert(NPT.offHeals, unit)
-							table.remove(NPT.nonTanks, unit)
-							break
+				if sourceGUID ~= destGUID and string.sub(destGUID, 1, 6) == "Player" then
+					NPT.nonHeals[sourceGUID] = timestamp
+					if sourceGUID == UnitGUID("player") then
+						if NPT.playerRole == "DAMAGER" then
+							--print("player is now HEALER")
+							NPT.playerRole = "HEALER"
+						end
+					else
+						for _, unit in ipairs(NPT.nonTanks) do
+							if sourceGUID == UnitGUID(unit) then
+								--print(unit .. " is now HEALER")
+								table.insert(NPT.offHeals, unit)
+								table.remove(NPT.nonTanks, unit)
+								break
+							end
 						end
 					end
 				end

--- a/NamePlatesThreat.lua
+++ b/NamePlatesThreat.lua
@@ -146,18 +146,27 @@ local function getGroupRoles()
 	else
 		unitPrefix = "party"
 	end
-	for i = 1, GetNumGroupMembers() do
+	for i = 1, MAX_RAID_MEMBERS do
 		unit = unitPrefix .. i
-		unitRole = UnitGroupRolesAssigned(unit)
-		if unitPrefix == "raid" and unitRole ~= "HEALER" then
-			_, raidRank, _, _, _, _, _, _, _, unitRole = GetRaidRosterInfo(i)
-			if unitRole == "MAINTANK" or unitRole == "MAINASSIST" or raidRank > 0 then
-				unitRole = "TANK"
+		unitRole = "NONE"
+		if unitPrefix == "party" and i >= GetNumGroupMembers() then
+			break
+		elseif UnitExists(unit) then
+			unitRole = UnitGroupRolesAssigned(unit)
+			if unitRole ~= "HEALER" then
+				if unitPrefix == "raid" then
+					_, raidRank, _, _, _, _, _, _, _, unitRole = GetRaidRosterInfo(i)
+				elseif UnitIsGroupLeader(unit) then
+					raidRank = 3
+				end
+				if unitRole == "MAINTANK" or unitRole == "MAINASSIST" or raidRank > 0 then
+					unitRole = "TANK"
+				end
 			end
 		end
 		if UnitIsUnit(unit, "player") then
 			collectedPlayer = unitRole
-		else
+		elseif unitRole ~= "NONE" then
 			if unitRole == "TANK" then
 				table.insert(collectedTanks, unit)
 			elseif unitRole == "HEALER" then

--- a/NamePlatesThreat.toc
+++ b/NamePlatesThreat.toc
@@ -1,4 +1,4 @@
-## Interface: 100002
+## Interface: 100005
 ## Title: NamePlatesThreat
 ## Notes: Colors the nameplate healthbar according to threat.
 ## Version: 3.5

--- a/NamePlatesThreat.toc
+++ b/NamePlatesThreat.toc
@@ -1,7 +1,7 @@
 ## Interface: 100002
 ## Title: NamePlatesThreat
 ## Notes: Colors the nameplate healthbar according to threat.
-## Version: 3.4
+## Version: 3.5
 ## Author: int3ro, exochron & mikfhan
 ## SavedVariables: NPTacct
 NamePlatesThreat.lua

--- a/NamePlatesThreat_TBC.toc
+++ b/NamePlatesThreat_TBC.toc
@@ -1,7 +1,7 @@
 ## Interface: 20504
 ## Title: NamePlatesThreat
 ## Notes: Colors the nameplate healthbar according to threat.
-## Version: 3.4
+## Version: 3.5
 ## Author: int3ro, exochron & mikfhan
 ## SavedVariables: NPTacct
 NamePlatesThreat.lua

--- a/NamePlatesThreat_Vanilla.toc
+++ b/NamePlatesThreat_Vanilla.toc
@@ -1,7 +1,7 @@
 ## Interface: 11403
 ## Title: NamePlatesThreat
 ## Notes: Colors the nameplate healthbar according to threat.
-## Version: 3.4
+## Version: 3.5
 ## Author: int3ro, exochron & mikfhan
 ## SavedVariables: NPTacct
 NamePlatesThreat.lua

--- a/NamePlatesThreat_Wrath.toc
+++ b/NamePlatesThreat_Wrath.toc
@@ -1,7 +1,7 @@
-## Interface: 30400
+## Interface: 30401
 ## Title: NamePlatesThreat
 ## Notes: Colors the nameplate healthbar according to threat.
-## Version: 3.4
+## Version: 3.5
 ## Author: int3ro, exochron & mikfhan
 ## SavedVariables: NPTacct
 NamePlatesThreat.lua

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Notice there is both a color for "you" and "tanks" even when you have a tank rol
 "Unique Colors as Non-Tank Role" lets you pick custom colors if you are a damager/healer role, otherwise addon reuses the color to the left of it.
 Notice there is a color for "you" but also healers and damage, this is so you know if YOU have aggro or if another damage/healer buddy has aggro.
 Note also how some role colors mention "you have the low threat" or "tanks have low threat" etc, this is when taunt skills are used to keep aggro.
-Note also how healers have a different color from damage role; healers are very important so ALL players in group should help tanks defend them.
+Note also how healers have a different color from damage; healers are very important so ALL players in group should help tanks defend them.
 
 "Color Gradient Updates Per Second" is an advanced feature; x times per second it fades the color between high and low as threat percent changes.
 Example if you are tank with high threat (green by default) then as threat is dropping toward only 100% it will fade toward the low color (gray).
 World of Warcraft generally treats anyone with 100% threat or more as "having aggro" for that enemy, and only taunt skills can override this.
 It may be crucial information as a tank to know if you are losing threat to one of the other players in the group, so they should cool off a bit.
 This option is advanced because all the color fading makes it harder to see exactly who has aggro when close to the 100% low threat target switch.
-Knowing this for hard-hitting bosses may still be preferred by some tanks. 
+Having this information for hard-hitting bosses may still be preferred by some tanks. 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Blizzard Nameplates - Threat  
 Extremely lightweight addon which colors the default blizzard nameplates according to threat.  
+See general usage in **bold** below. Settings are saved in your WoW \_retail\_ (or similar) subfolder:  
+WTF\Account\\\<userid\>\SavedVariables\NamePlatesThreat.lua  
 You can tweak settings/colors below from Escape menu > Interface/Options > AddOns > NamePlatesThreat  
-Settings are saved in your World of Warcraft \_retail\_ (or similar) subfolder:  
-WTF\Account\\<userid>\SavedVariables\NamePlatesThreat.lua  
 
 "Color Non-Friendly Nameplates" addon option you can quickly disable if you want Blizzard colors always.  
 "Color Nameplate Border Only" (retail only) ensures healthbar inside still uses original Blizzard colors.  
@@ -39,7 +39,7 @@ GREEN: Tanks have High Threat (fire at will, tanks are on it)
 **Everyone should attack red, then tanks attack orange before yellow, others attack green before gray.**  
 
 "Color Nameplates by Threat" you can disable if you only wish to color enemies by their target instead of threat, it still uses the colors below.
-The role colors just below lets you customize colors when you have the tank role, you disable the checkbox above again after tweaking the colors.
+The role colors just below lets you customize colors when you have the tank role, you can disable checkbox above again after tweaking the colors.
 Notice there is both a color for "you" and "tanks" even when you have a tank role, this is so you know if YOU have aggro or an offtank buddy does.
 "Unique Colors In-Between" lets you pick custom colors when someone is using taunt skills, if disabled addon just reuses the colors from above.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Notice there is both a color for "you" and "tanks" even when you have a tank rol
 "Unique Colors as Non-Tank Role" lets you pick custom colors if you are a damager/healer role, otherwise addon reuses the color to the left of it.
 Notice there is a color for "you" but also healers and damage, this is so you know if YOU have aggro or if another damage/healer buddy has aggro.
 Note also how some role colors mention "you have the low threat" or "tanks have low threat" etc, this is when taunt skills are used to keep aggro.
-Note also how healers have a different color from damage; healers are very important so ALL players in group should help tanks defend them.
+Note also how healers have a different color from damage; healers are very important so ALL players should help tanks defend them.
 
 "Color Gradient Updates Per Second" is an advanced feature; x times per second it fades the color between high and low as threat percent changes.
 Example if you are tank with high threat (green by default) then as threat is dropping toward only 100% it will fade toward the low color (gray).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ See general usage in **bold** below. Settings are saved in your WoW \_retail\_ (
 WTF\Account\\\<userid\>\SavedVariables\NamePlatesThreat.lua  
 You can tweak settings/colors below from Escape menu > Interface/Options > AddOns > NamePlatesThreat  
 
+**Everyone should attack red, then tanks attack orange before yellow, others attack green before gray.**  
+
 "Color Non-Friendly Nameplates" addon option you can quickly disable if you want Blizzard colors always.  
 "Color Nameplate Border Only" (retail only) ensures healthbar inside still uses original Blizzard colors.  
 
@@ -18,9 +20,9 @@ Out of combat topmost three colors below indicate if enemy is a player, or hosti
 "Color Player Characters" for PvP enemies depending on role they are targeting (never based on NPC threat).  
 
 **Colors Out of Combat (2.7-release and newer):**  
-PINK: Player is Out of Combat (only if PvP colors enabled and no target)  
 VIOLET: Hostile Out of Combat (turns blue if fighting totems/NPCs/others)  
 BLUE: Neutral Out of Combat (or hostiles fighting totems/NPCs/others)  
+PINK: Player is Out of Combat (only if PvP colors enabled and no target)  
 
 **Playing as Tank role (2.7-release and newer):**  
 RED: Healers have High Threat (emergency! get on it asap)  
@@ -36,8 +38,6 @@ YELLOW: You have the Low Threat (hold attacks, wait for tank)
 GRAY: Damage has High Threat (okay to attack, but not much)  
 GREEN: Tanks have High Threat (fire at will, tanks are on it)  
 
-**Everyone should attack red, then tanks attack orange before yellow, others attack green before gray.**  
-
 "Color Nameplates by Threat" you can disable if you only wish to color enemies by their target instead of threat, it still uses the colors below.
 The role colors just below lets you customize colors when you have the tank role, you can disable checkbox above again after tweaking the colors.
 Notice there is both a color for "you" and "tanks" even when you have a tank role, this is so you know if YOU have aggro or an offtank buddy does.
@@ -52,5 +52,5 @@ Note also how healers have a different color from damage; healers are very impor
 Example if you are tank with high threat (green by default) then as threat is dropping toward only 100% it will fade toward the low color (gray).
 World of Warcraft generally treats anyone with 100% threat or more as "having aggro" for that enemy, and only taunt skills can override this.
 It may be crucial information as a tank to know if you are losing threat to one of the other players in the group, so they should cool off a bit.
-This option is advanced because all the color fading makes it harder to see exactly who has aggro when close to the 100% low threat target switch.
+This option is advanced because color fading makes it harder to see exactly who has aggro when close to the 100% low threat target switchover.
 Having this information for hard-hitting bosses may still be preferred by some tanks. 

--- a/README.md
+++ b/README.md
@@ -1,54 +1,54 @@
 # Blizzard Nameplates - Threat  
-Extremely lightweight addon which colors the default blizzard nameplates according to threat.
-You can tweak a few settings and colors below from Escape menu > Interface/Options > AddOns > NamePlatesThreat
-Settings are saved in your World of Warcraft \_retail\_ (or similar) subfolder: WTF\Account\<userid>\SavedVariables\NamePlatesThreat.lua
+Extremely lightweight addon which colors the default blizzard nameplates according to threat.  
+You can tweak a few settings and colors below from Escape menu > Interface/Options > AddOns > NamePlatesThreat  
+Settings are saved in your World of Warcraft \_retail\_ (or similar) subfolder: WTF\Account\<userid>\SavedVariables\NamePlatesThreat.lua  
 
-"Color Non-Friendly Nameplates" addon option you can quickly disable if you want original Blizzard colors displayed for a while no matter what.
-"Color Nameplate Border Only" will only color the edge of the nameplate (retail only) so healthbar inside still uses original Blizzard colors.
+"Color Non-Friendly Nameplates" addon option you can quickly disable if you want original Blizzard colors displayed for a while no matter what.  
+"Color Nameplate Border Only" will only color the edge of the nameplate (retail only) so healthbar inside still uses original Blizzard colors.  
 
-The addon decides group member roles (tank/damager/healer) via Set Role option from right-clicking their player portrait, with some exceptions:
-Retail treats you the player purely by your talent spec, regardless of your group role (you can still Set Role on other players as above).
-Wrath Classic lets you Set Role default via the round icon at the top right of your talent panel (you can still Set Role on other players as above).
-Classic Era has no roles, but treats the group leader or raid maintank/assist as a tank, and anyone else healing within last 60 seconds as a healer.
-"Color Group Pets as Tanks" is an addon option that treats all pets as a tank even if their player is not.
+The addon decides group member roles (tank/damager/healer) via Set Role option from right-clicking their player portrait, with some exceptions:  
+Retail treats you the player purely by your talent spec, regardless of your group role (you can still Set Role on other players as above).  
+Wrath Classic lets you Set Role default via the round icon at the top right of your talent panel (you can still Set Role on other players as above).  
+Classic Era has no roles, but treats the group leader or raid maintank/assist as a tank, and anyone else healing within last 60 seconds as a healer.  
+"Color Group Pets as Tanks" is an addon option that treats all pets as a tank even if their player is not.  
 
-"Color out of Dungeons" and "Color Out of Combat" you can disable if you want original Blizzard colors outside those situations.
-Out of combat you might notice the topmost three colors below, they indicate if enemy is a player, or an NPC with hostile or neutral reputation.
-"Color Player Characters" can color PvP enemies depending on which role in your group they are currently targeting (this is never based on threat).
+"Color out of Dungeons" and "Color Out of Combat" you can disable if you want original Blizzard colors outside those situations.  
+Out of combat you might notice the topmost three colors below, they indicate if enemy is a player, or an NPC with hostile or neutral reputation.  
+"Color Player Characters" can color PvP enemies depending on which role in your group they are currently targeting (this is never based on threat).  
 
-**Colors Out of Combat (2.7-release and newer):**
-PINK: Player is Out of Combat (only if PvP colors enabled and no target)
-VIOLET: Hostile Out of Combat (turns blue if fighting totems/NPCs/others)
-BLUE: Neutral Out of Combat (or hostiles fighting totems/NPCs/others)
+**Colors Out of Combat (2.7-release and newer):**  
+PINK: Player is Out of Combat (only if PvP colors enabled and no target)  
+VIOLET: Hostile Out of Combat (turns blue if fighting totems/NPCs/others)  
+BLUE: Neutral Out of Combat (or hostiles fighting totems/NPCs/others)  
 
-**Playing as Tank role (2.7-release and newer):**
-RED: Healers have High Threat (emergency! get on it asap)
-ORANGE: Damage has High Threat (not good, defend your dps)
-YELLOW: Tanks have Low Threat (offtanks struggle, help them)
-GRAY: You have the Low Threat (or offtanks have high threat)
-GREEN: You have the High Threat (perfect tank, ignore these)
+**Playing as Tank role (2.7-release and newer):**  
+RED: Healers have High Threat (emergency! get on it asap)  
+ORANGE: Damage has High Threat (not good, defend your dps)  
+YELLOW: Tanks have Low Threat (offtanks struggle, help them)  
+GRAY: You have the Low Threat (or offtanks have high threat)  
+GREEN: You have the High Threat (perfect tank, ignore these)  
 
-**Damage or Heal role (2.7-release and newer):**
-RED: Healers have High Threat (emergency! get on it asap)
-ORANGE: You have the High Threat (disengage! find a tank)
-YELLOW: You have the Low Threat (hold attacks, wait for tank)
-GRAY: Damage has High Threat (okay to attack, but not much)
-GREEN: Tanks have High Threat (fire at will, tanks are on it)
+**Damage or Heal role (2.7-release and newer):**  
+RED: Healers have High Threat (emergency! get on it asap)  
+ORANGE: You have the High Threat (disengage! find a tank)  
+YELLOW: You have the Low Threat (hold attacks, wait for tank)  
+GRAY: Damage has High Threat (okay to attack, but not much)  
+GREEN: Tanks have High Threat (fire at will, tanks are on it)  
 
-**General advice is everyone should attack red plates, then tanks attack orange before yellow, while others attack green before gray plates.**
+**General advice is everyone should attack red plates, then tanks attack orange before yellow, while others attack green before gray plates.**  
 
-"Color Nameplates by Threat" you can disable if you only wish to color enemies by their target instead of threat, it still uses the colors below.
-The role colors just below lets you customize colors when you have the tank role, you disable the checkbox above again after tweaking the colors.
-Notice there is both a color for "you" and "tanks" even when you have a tank role, this is so you know if YOU have aggro or an offtank buddy does.
-"Unique Colors In-Between" lets you pick custom colors when someone is using taunt skills, if disabled addon just reuses the colors from above.
+"Color Nameplates by Threat" you can disable if you only wish to color enemies by their target instead of threat, it still uses the colors below.  
+The role colors just below lets you customize colors when you have the tank role, you disable the checkbox above again after tweaking the colors.  
+Notice there is both a color for "you" and "tanks" even when you have a tank role, this is so you know if YOU have aggro or an offtank buddy does.  
+"Unique Colors In-Between" lets you pick custom colors when someone is using taunt skills, if disabled addon just reuses the colors from above.  
 
-"Unique Colors as Non-Tank Role" lets you pick custom colors if you are a damager/healer role, otherwise addon reuses the color to the left of it.
-Notice there is a color for "you" but also healers and damage, this is so you know if YOU have aggro or if another damage/healer buddy has aggro.
-Note also how some role colors mention "you have the low threat" or "tanks have low threat" etc, this is when taunt skills are used to keep aggro.
-Note also how healers have a different color from damage role; healers are very important so ALL players in group should help tanks defend them.
+"Unique Colors as Non-Tank Role" lets you pick custom colors if you are a damager/healer role, otherwise addon reuses the color to the left of it.  
+Notice there is a color for "you" but also healers and damage, this is so you know if YOU have aggro or if another damage/healer buddy has aggro.  
+Note also how some role colors mention "you have the low threat" or "tanks have low threat" etc, this is when taunt skills are used to keep aggro.  
+Note also how healers have a different color from damage role; healers are very important so ALL players in group should help tanks defend them.  
 
-"Color Gradient Updates Per Second" is an advanced feature; x times per second it fades the color between high and low as threat percent changes.
-Example if you are tank with high threat (green by default) then as threat is dropping toward only 100% it will fade toward the low color (gray).
-World of Warcraft generally treats anyone with 100% threat or more as "having aggro" for that enemy, and only taunt skills can override this.
-It may be crucial information as a tank to know if you are losing threat to one of the other players in the group, so they should cool off a bit.
+"Color Gradient Updates Per Second" is an advanced feature; x times per second it fades the color between high and low as threat percent changes.  
+Example if you are tank with high threat (green by default) then as threat is dropping toward only 100% it will fade toward the low color (gray).  
+World of Warcraft generally treats anyone with 100% threat or more as "having aggro" for that enemy, and only taunt skills can override this.  
+It may be crucial information as a tank to know if you are losing threat to one of the other players in the group, so they should cool off a bit.  
 This option is advanced because all the color fading makes it harder to see exactly who has aggro get closer to 100% low threat target switch.

--- a/README.md
+++ b/README.md
@@ -52,4 +52,5 @@ Note also how healers have a different color from damage role; healers are very 
 Example if you are tank with high threat (green by default) then as threat is dropping toward only 100% it will fade toward the low color (gray).
 World of Warcraft generally treats anyone with 100% threat or more as "having aggro" for that enemy, and only taunt skills can override this.
 It may be crucial information as a tank to know if you are losing threat to one of the other players in the group, so they should cool off a bit.
-This option is advanced because all the color fading makes it harder to see exactly who has aggro get closer to 100% low threat target switch.
+This option is advanced because all the color fading makes it harder to see exactly who has aggro when close to the 100% low threat target switch.
+Knowing this for hard-hitting bosses may still be preferred by some tanks. 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
 # Blizzard Nameplates - Threat  
 Extremely lightweight addon which colors the default blizzard nameplates according to threat.  
-You can tweak a few settings and colors below from Escape menu > Interface/Options > AddOns > NamePlatesThreat  
-Settings are saved in your World of Warcraft \_retail\_ (or similar) subfolder: WTF\Account\<userid>\SavedVariables\NamePlatesThreat.lua  
+You can tweak settings/colors below from Escape menu > Interface/Options > AddOns > NamePlatesThreat  
+Settings are saved in your World of Warcraft \_retail\_ (or similar) subfolder:  
+WTF\Account\\<userid>\SavedVariables\NamePlatesThreat.lua  
 
-"Color Non-Friendly Nameplates" addon option you can quickly disable if you want original Blizzard colors displayed for a while no matter what.  
-"Color Nameplate Border Only" will only color the edge of the nameplate (retail only) so healthbar inside still uses original Blizzard colors.  
+"Color Non-Friendly Nameplates" addon option you can quickly disable if you want Blizzard colors always.  
+"Color Nameplate Border Only" (retail only) ensures healthbar inside still uses original Blizzard colors.  
 
-The addon decides group member roles (tank/damager/healer) via Set Role option from right-clicking their player portrait, with some exceptions:  
-Retail treats you the player purely by your talent spec, regardless of your group role (you can still Set Role on other players as above).  
-Wrath Classic lets you Set Role default via the round icon at the top right of your talent panel (you can still Set Role on other players as above).  
-Classic Era has no roles, but treats the group leader or raid maintank/assist as a tank, and anyone else healing within last 60 seconds as a healer.  
+The addon decides player roles via Set Role right-clicking their player portrait, with some exceptions:  
+Retail treats you purely by your talent spec, regardless of group role (you can still Set Role on others).  
+Wrath lets you Set Role default via the round icon top right of your talent panel (or Set Role on others).  
+Classic Era has no roles; leader or raid maintank/assist are tank, others healing within last 60 seconds.  
 "Color Group Pets as Tanks" is an addon option that treats all pets as a tank even if their player is not.  
 
-"Color out of Dungeons" and "Color Out of Combat" you can disable if you want original Blizzard colors outside those situations.  
-Out of combat you might notice the topmost three colors below, they indicate if enemy is a player, or an NPC with hostile or neutral reputation.  
-"Color Player Characters" can color PvP enemies depending on which role in your group they are currently targeting (this is never based on threat).  
+"Color out of Dungeons" and "Color Out of Combat" if disabled use Blizzard colors outside those situations.  
+Out of combat topmost three colors below indicate if enemy is a player, or hostile/neutral NPC reputation.  
+"Color Player Characters" for PvP enemies depending on role they are targeting (never based on NPC threat).  
 
 **Colors Out of Combat (2.7-release and newer):**  
 PINK: Player is Out of Combat (only if PvP colors enabled and no target)  
@@ -35,20 +36,20 @@ YELLOW: You have the Low Threat (hold attacks, wait for tank)
 GRAY: Damage has High Threat (okay to attack, but not much)  
 GREEN: Tanks have High Threat (fire at will, tanks are on it)  
 
-**General advice is everyone should attack red plates, then tanks attack orange before yellow, while others attack green before gray plates.**  
+**Everyone should attack red, then tanks attack orange before yellow, others attack green before gray.**  
 
-"Color Nameplates by Threat" you can disable if you only wish to color enemies by their target instead of threat, it still uses the colors below.  
-The role colors just below lets you customize colors when you have the tank role, you disable the checkbox above again after tweaking the colors.  
-Notice there is both a color for "you" and "tanks" even when you have a tank role, this is so you know if YOU have aggro or an offtank buddy does.  
-"Unique Colors In-Between" lets you pick custom colors when someone is using taunt skills, if disabled addon just reuses the colors from above.  
+"Color Nameplates by Threat" you can disable if you only wish to color enemies by their target instead of threat, it still uses the colors below.
+The role colors just below lets you customize colors when you have the tank role, you disable the checkbox above again after tweaking the colors.
+Notice there is both a color for "you" and "tanks" even when you have a tank role, this is so you know if YOU have aggro or an offtank buddy does.
+"Unique Colors In-Between" lets you pick custom colors when someone is using taunt skills, if disabled addon just reuses the colors from above.
 
-"Unique Colors as Non-Tank Role" lets you pick custom colors if you are a damager/healer role, otherwise addon reuses the color to the left of it.  
-Notice there is a color for "you" but also healers and damage, this is so you know if YOU have aggro or if another damage/healer buddy has aggro.  
-Note also how some role colors mention "you have the low threat" or "tanks have low threat" etc, this is when taunt skills are used to keep aggro.  
-Note also how healers have a different color from damage role; healers are very important so ALL players in group should help tanks defend them.  
+"Unique Colors as Non-Tank Role" lets you pick custom colors if you are a damager/healer role, otherwise addon reuses the color to the left of it.
+Notice there is a color for "you" but also healers and damage, this is so you know if YOU have aggro or if another damage/healer buddy has aggro.
+Note also how some role colors mention "you have the low threat" or "tanks have low threat" etc, this is when taunt skills are used to keep aggro.
+Note also how healers have a different color from damage role; healers are very important so ALL players in group should help tanks defend them.
 
-"Color Gradient Updates Per Second" is an advanced feature; x times per second it fades the color between high and low as threat percent changes.  
-Example if you are tank with high threat (green by default) then as threat is dropping toward only 100% it will fade toward the low color (gray).  
-World of Warcraft generally treats anyone with 100% threat or more as "having aggro" for that enemy, and only taunt skills can override this.  
-It may be crucial information as a tank to know if you are losing threat to one of the other players in the group, so they should cool off a bit.  
+"Color Gradient Updates Per Second" is an advanced feature; x times per second it fades the color between high and low as threat percent changes.
+Example if you are tank with high threat (green by default) then as threat is dropping toward only 100% it will fade toward the low color (gray).
+World of Warcraft generally treats anyone with 100% threat or more as "having aggro" for that enemy, and only taunt skills can override this.
+It may be crucial information as a tank to know if you are losing threat to one of the other players in the group, so they should cool off a bit.
 This option is advanced because all the color fading makes it harder to see exactly who has aggro get closer to 100% low threat target switch.

--- a/README.md
+++ b/README.md
@@ -1,33 +1,54 @@
 # Blizzard Nameplates - Threat  
-Extremely lightweight addon which colors the default blizzard nameplates according to threat.  
+Extremely lightweight addon which colors the default blizzard nameplates according to threat.
+You can tweak a few settings and colors below from Escape menu > Interface/Options > AddOns > NamePlatesThreat
+Settings are saved in your World of Warcraft \_retail\_ (or similar) subfolder: WTF\Account\<userid>\SavedVariables\NamePlatesThreat.lua
 
-General advice is everyone should attack red nameplates, then tanks should attack orange before yellow while others attack green before gray nameplates.  
+"Color Non-Friendly Nameplates" addon option you can quickly disable if you want original Blizzard colors displayed for a while no matter what.
+"Color Nameplate Border Only" will only color the edge of the nameplate (retail only) so healthbar inside still uses original Blizzard colors.
 
-You can tweak a few settings and colors below from Escape menu > Interface > AddOns > NamePlatesThreat:  
+The addon decides group member roles (tank/damager/healer) via Set Role option from right-clicking their player portrait, with some exceptions:
+Retail treats you the player purely by your talent spec, regardless of your group role (you can still Set Role on other players as above).
+Wrath Classic lets you Set Role default via the round icon at the top right of your talent panel (you can still Set Role on other players as above).
+Classic Era has no roles, but treats the group leader or raid maintank/assist as a tank, and anyone else healing within last 60 seconds as a healer.
+"Color Group Pets as Tanks" is an addon option that treats all pets as a tank even if their player is not.
 
-Colors Out of Combat (2.4-release):  
+"Color out of Dungeons" and "Color Out of Combat" you can disable if you want original Blizzard colors outside those situations.
+Out of combat you might notice the topmost three colors below, they indicate if enemy is a player, or an NPC with hostile or neutral reputation.
+"Color Player Characters" can color PvP enemies depending on which role in your group they are currently targeting (this is never based on threat).
 
-PINK: Player is Out of Combat (only if PvP colors enabled and no target)  
-VIOLET: Hostile Out of Combat (or gray if fighting totems/NPCs/others)  
-BLUE: Neutral Out of Combat (or gray if fighting totems/NPCs/others)  
+**Colors Out of Combat (2.7-release and newer):**
+PINK: Player is Out of Combat (only if PvP colors enabled and no target)
+VIOLET: Hostile Out of Combat (turns blue if fighting totems/NPCs/others)
+BLUE: Neutral Out of Combat (or hostiles fighting totems/NPCs/others)
 
-Playing as Tank spec (2.4-release):  
+**Playing as Tank role (2.7-release and newer):**
+RED: Healers have High Threat (emergency! get on it asap)
+ORANGE: Damage has High Threat (not good, defend your dps)
+YELLOW: Tanks have Low Threat (offtanks struggle, help them)
+GRAY: You have the Low Threat (or offtanks have high threat)
+GREEN: You have the High Threat (perfect tank, ignore these)
 
-RED: Healers have High Threat (emergency! get on it asap)  
-ORANGE: Damage has High Threat (not good, defend your dps)  
-YELLOW: Tanks have Low Threat (offtanks struggle, help them)  
-GRAY: You have the Low Threat (tanking, but not perfect)  
-GREEN: You have the High Threat (perfect tank, ignore these)  
+**Damage or Heal role (2.7-release and newer):**
+RED: Healers have High Threat (emergency! get on it asap)
+ORANGE: You have the High Threat (disengage! find a tank)
+YELLOW: You have the Low Threat (hold attacks, wait for tank)
+GRAY: Damage has High Threat (okay to attack, but not much)
+GREEN: Tanks have High Threat (fire at will, tanks are on it)
 
-Damage or Heal spec (2.4-release):  
+**General advice is everyone should attack red plates, then tanks attack orange before yellow, while others attack green before gray plates.**
 
-RED: Healers have High Threat (emergency! get on it asap)  
-ORANGE: You have the High Threat (disengage! find a tank)  
-YELLOW: You have the Low Threat (hold attacks, wait for tank)  
-GRAY: Damage has High Threat (okay to attack, but not much)  
-GREEN: Tanks have High Threat (fire at will, tanks are on it)  
+"Color Nameplates by Threat" you can disable if you only wish to color enemies by their target instead of threat, it still uses the colors below.
+The role colors just below lets you customize colors when you have the tank role, you disable the checkbox above again after tweaking the colors.
+Notice there is both a color for "you" and "tanks" even when you have a tank role, this is so you know if YOU have aggro or an offtank buddy does.
+"Unique Colors In-Between" lets you pick custom colors when someone is using taunt skills, if disabled addon just reuses the colors from above.
 
-Settings are saved in your World of Warcraft _retail_ subfolder:  
-WTF\Account\<userid>\SavedVariables\NamePlatesThreat.lua  
+"Unique Colors as Non-Tank Role" lets you pick custom colors if you are a damager/healer role, otherwise addon reuses the color to the left of it.
+Notice there is a color for "you" but also healers and damage, this is so you know if YOU have aggro or if another damage/healer buddy has aggro.
+Note also how some role colors mention "you have the low threat" or "tanks have low threat" etc, this is when taunt skills are used to keep aggro.
+Note also how healers have a different color from damage role; healers are very important so ALL players in group should help tanks defend them.
 
-Anyone from TidyPlates who prefer old colors before 1.8-release can find them in Issue #4 third comment, which has a SavedVariables file you can overwrite (remember to logout your characters while doing so).  
+"Color Gradient Updates Per Second" is an advanced feature; x times per second it fades the color between high and low as threat percent changes.
+Example if you are tank with high threat (green by default) then as threat is dropping toward only 100% it will fade toward the low color (gray).
+World of Warcraft generally treats anyone with 100% threat or more as "having aggro" for that enemy, and only taunt skills can override this.
+It may be crucial information as a tank to know if you are losing threat to one of the other players in the group, so they should cool off a bit.
+This option is advanced because all the color fading makes it harder to see exactly who has aggro get closer to 100% low threat target switch.


### PR DESCRIPTION
Wrath Classic 3.4.1 and Retail 10.0.5 compatibility.
Non-healer group leaders now treated as offtanks.
Classic Era healers detected via combat log heals.
Retain white border after combat for selected target.
Readme.md added more addon options explanation.